### PR TITLE
chore(railway): remove nested sh -lc; use POSIX path detection in Railpack steps

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,27 +1,23 @@
 {
   "$schema": "https://schema.railpack.com",
   "provider": "node",
-  "packages": {
-    "node": "22"
-  },
-  "caches": {
-    "npm-install": { "directory": "/root/.npm", "type": "shared" }
-  },
+  "packages": { "node": "22" },
+  "caches": { "npm-install": { "directory": "/root/.npm", "type": "shared" } },
   "steps": {
     "install": {
       "commands": [
-        "sh -lc 'for d in . .. ../.. /workspace /app; do if [ -f \"$d/package-lock.json\" ]; then cd \"$d\" && npm ci --legacy-peer-deps && exit 0; fi; done; echo \"No package-lock.json found\"; exit 1'"
+        "if [ -f package-lock.json ]; then :; elif [ -f ../package-lock.json ]; then cd ..; elif [ -f ../../package-lock.json ]; then cd ../..; elif [ -f /workspace/package-lock.json ]; then cd /workspace; elif [ -f /app/package-lock.json ]; then cd /app; else echo No package-lock.json found; exit 1; fi; npm ci --legacy-peer-deps"
       ],
       "caches": ["npm-install"]
     },
     "build": {
       "inputs": [{ "step": "install" }],
       "commands": [
-        "sh -lc 'for d in . .. ../.. /workspace /app; do if [ -f \"$d/package-lock.json\" ]; then cd \"$d\" && npm run prisma:generate && npm run translate:compile && npm run build && exit 0; fi; done; echo \"Could not locate repo root for build\"; exit 1'"
+        "if [ -f package-lock.json ]; then :; elif [ -f ../package-lock.json ]; then cd ..; elif [ -f ../../package-lock.json ]; then cd ../..; elif [ -f /workspace/package-lock.json ]; then cd /workspace; elif [ -f /app/package-lock.json ]; then cd /app; else echo Repo root not found; exit 1; fi; npm run prisma:generate && npm run translate:compile && npm run build"
       ]
     }
   },
   "deploy": {
-    "startCommand": "sh -lc 'for d in . .. ../.. /workspace /app; do if [ -f \"$d/package-lock.json\" ]; then cd \"$d\" && npm run start; exit; fi; done; echo \"Could not locate repo root for start\"; exit 1'"
+    "startCommand": "if [ -f package-lock.json ]; then :; elif [ -f ../package-lock.json ]; then cd ..; elif [ -f ../../package-lock.json ]; then cd ../..; elif [ -f /workspace/package-lock.json ]; then cd /workspace; elif [ -f /app/package-lock.json ]; then cd /app; else echo Repo root not found; exit 1; fi; npm run start"
   }
 }


### PR DESCRIPTION
Replace nested `sh -lc` + for-loop with pure POSIX checks to locate repo root before running npm.

- Avoids shell quoting issues ("Bad for loop variable") seen on Railway
- Commands now: detect repo root (package-lock.json) then run npm ci/build/start

Files:
- railpack.json

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author